### PR TITLE
Add Component Description to Templating Engine

### DIFF
--- a/ParametricText.py
+++ b/ParametricText.py
@@ -76,7 +76,7 @@ PANEL_IDS = [
         ]
 
 QUICK_REF = '''<b>Quick Reference</b><br>
-{_.component}, {_.sketch}, {_.date}, {_.file}, {_.version}<br>
+{_.component}, {_.sketch}, {_.date}, {_.file}, {_.version}, {_.description}<br>
 {param}|{param.value}, {param.expr}, {param.unit}, {param.comment}<br>
 <br>
 {_.version:03} = 024 (integer)<br>
@@ -889,6 +889,9 @@ def evaluate_text(text, sketch_text, next_version=False):
                 component_name = sketch_text.parentSketch.parentComponent.name
                 component_name = DOCUMENT_NAME_VERSION_PATTERN.sub('', component_name)
                 value = component_name
+                string_value = True
+            elif member == 'description':
+                value = sketch_text.parentSketch.parentComponent.description
                 string_value = True
             elif member == 'file':
                 ### Can we handle "Save as" or document copying?

--- a/ParametricText.py
+++ b/ParametricText.py
@@ -76,7 +76,7 @@ PANEL_IDS = [
         ]
 
 QUICK_REF = '''<b>Quick Reference</b><br>
-{_.component}, {_.sketch}, {_.date}, {_.file}, {_.version}, {_.description}<br>
+{_.component}, {_.sketch}, {_.date}, {_.file}, {_.version}, {_.compdesc}<br>
 {param}|{param.value}, {param.expr}, {param.unit}, {param.comment}<br>
 <br>
 {_.version:03} = 024 (integer)<br>
@@ -890,7 +890,7 @@ def evaluate_text(text, sketch_text, next_version=False):
                 component_name = DOCUMENT_NAME_VERSION_PATTERN.sub('', component_name)
                 value = component_name
                 string_value = True
-            elif member == 'description':
+            elif member == 'compdesc':
                 value = sketch_text.parentSketch.parentComponent.description
                 string_value = True
             elif member == 'file':

--- a/ParametricText.py
+++ b/ParametricText.py
@@ -1289,6 +1289,9 @@ def command_terminated_handler(args: adsk.core.ApplicationCommandEventArgs):
     elif args.commandId == 'FusionPasteNewCommand':
         # User pasted a component, that will have a new name
         update_texts_async(text_filter=['_.component'])
+    elif args.commandId == 'FusionPropertiesCommand':  
+        # User changed component properties  
+        update_texts_async(text_filter=['_.component', '_.compdesc'])
     elif (args.commandId in ['RenameCommand',
                              'FusionRenameTimelineEntryCommand']):
         # User might have changed a component or sketch name

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -6,6 +6,10 @@ Author
 
 This add-in is created by Thomas Axelsson.
 
+Contributors
+-------
+* John Marsden (ProfDoof)
+
 License
 -------
 

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -66,7 +66,7 @@ ParametricText includes a special parameter, ``_``, that does not exist in the F
 |               |          |containing   |            |
 |               |          |the text     |            |
 +===============+==========+=============+============+
-| _.description | string   |Description  | Complex    |
+| _.compdesc    | string   |Description  | Complex    |
 |               |          |of component | Description|
 |               |          |containing   | in the     |
 |               |          |the text     | Component  |

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -65,7 +65,7 @@ ParametricText includes a special parameter, ``_``, that does not exist in the F
 |               |          |component    |            |
 |               |          |containing   |            |
 |               |          |the text     |            |
-+===============+==========+=============+============+
++---------------+----------+-------------+------------+
 | _.compdesc    | string   |Description  | Complex    |
 |               |          |of component | Description|
 |               |          |containing   | in the     |

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -65,6 +65,11 @@ ParametricText includes a special parameter, ``_``, that does not exist in the F
 |               |          |component    |            |
 |               |          |containing   |            |
 |               |          |the text     |            |
++===============+==========+=============+============+
+| _.description | string   |Description  | Complex    |
+|               |          |of component | Description|
+|               |          |containing   | in the     |
+|               |          |the text     | Component  |
 +---------------+----------+-------------+------------+
 | _.date [#]_   | datetime |Date & time  | 2021-07-06 |
 |               |          |when the     |            |


### PR DESCRIPTION
Hi! I started using your add-in for a 3D model I needed but I wanted to be able to configure the text using the configurations feature. I didn't want to get to out into the weeds so I just leveraged the fact that configurations can change the description and used that. I would have used `_.component` however, the configurations table doesn't actually change the name of the root component, it simply uses that name for the configuration. (Or I'm doing something wrong) However, the description for the root component does get changed based on the configuration description. 